### PR TITLE
getIssuesForBacklog not supporting some parameters - 352 version only

### DIFF
--- a/api/board.js
+++ b/api/board.js
@@ -143,6 +143,9 @@ function AgileBoardClient(jiraClient) {
    * @memberOf AgileBoardClient#
    * @param opts The request options to send to the Jira API
    * @param opts.boardId The agile board id.
+   * @param {string} jql Filters results using a JQL query.
+   * @param {boolean} validateQuery Specifies whether to valide the JQL query.
+   * @param {string} fields The list of fields to return for each issue.
    * @param [opts.startAt] The index of the first dashboard to return (0-based). must be 0 or a multiple of
    *     maxResults
    * @param [opts.maxResults] A hint as to the the maximum number of issues to return in each call. Note that the
@@ -161,7 +164,10 @@ function AgileBoardClient(jiraClient) {
       followAllRedirects: true,
       qs: {
         startAt: opts.startAt,
-        maxResults: opts.maxResults
+        maxResults: opts.maxResults,
+        jql: opts.jql,
+        validateQuery: opts.validateQuery,
+        fields: opts.fields
       }
     };
 


### PR DESCRIPTION
From the [PR](https://github.com/floralvikings/jira-connector/pull/94) in the base repository

This PR resolves #92.
Unsupported parameters per JIRA API docs: fields, sql, validateQuery
Update uses comments / code from: api / sprint.js / getSprintIssues()


